### PR TITLE
Build: Add new Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.9
+
+WORKDIR $HOME
+RUN apt-get install libssl-dev
+RUN pip3 install ecdsa
+
+RUN git clone https://github.com/hyperledger/fabric-sdk-py.git
+WORKDIR $HOME/fabric-sdk-py
+RUN git checkout tags/v0.8.0
+RUN make install
+
+WORKDIR /usr/src/app
+COPY . .
+
+CMD ["python", "./fabpki-cli/message-ecdsa.py", "1", "teste", "2"]
+
+


### PR DESCRIPTION
Add new Dockerfile to build container image in order to investigate the simulation of different hardware running a blockchain client